### PR TITLE
Specifying User-Agent values for bots #156

### DIFF
--- a/BotCore/BotCore.cs
+++ b/BotCore/BotCore.cs
@@ -51,6 +51,8 @@ public class Core
 
     private bool _useLowCpuRam;
 
+    private int _userAgentIndex = 0;
+
     public Action AllBrowsersTerminated;
 
     public bool CanRun = true;
@@ -156,10 +158,12 @@ public class Core
                         PreferredQuality = executeNeeds.PreferredQuality,
                         LoginInfo = loginInfo,
                         Service = executeNeeds.Service,
-                        Proxy = proxy
+                        Proxy = proxy,
+                        UserAgentString = executeNeeds.UserAgentStrings.Count > 0 ? executeNeeds.UserAgentStrings[_userAgentIndex] : string.Empty,
                     });
 
                     i++;
+                    _userAgentIndex = (_userAgentIndex + 1) % executeNeeds.UserAgentStrings.Count;
 
                     Thread.Sleep(BrowserLimit == 0 ? rInt : 1000);
                 }
@@ -337,6 +341,11 @@ public class Core
                 Timeout = 120000,
                 Proxy = itm.Proxy
             };
+
+            if (!string.IsNullOrWhiteSpace(itm.UserAgentString))
+            {
+                browserLaunchOptions.UserAgent = itm.UserAgentString;
+            }
 
             if (_useLowCpuRam)
             {

--- a/BotCore/Dto/ExecuteNeedsDto.cs
+++ b/BotCore/Dto/ExecuteNeedsDto.cs
@@ -7,6 +7,8 @@ public class ExecuteNeedsDto
 {
     public string ProxyListDirectory { get; set; }
 
+    public List<string> UserAgentStrings { get; set; } = new List<string>();
+
     public List<string> ChatMessages { get; set; } = new List<string>();
 
     public string Stream { get; set; }

--- a/BotCore/Dto/SessionConfigurationDto.cs
+++ b/BotCore/Dto/SessionConfigurationDto.cs
@@ -15,5 +15,7 @@ namespace BotCore.Dto
         public StreamService.Service Service { get; set; }
 
         public Proxy Proxy { get; set; }
+
+        public string UserAgentString { get; set; }
     }
 }

--- a/StreamViewerBot/App.config
+++ b/StreamViewerBot/App.config
@@ -2,6 +2,7 @@
 <configuration>
     <appSettings>
         <add key="proxyListDirectory" value=""/>
+		<add key="userAgentListDirectory" value=""/>
 		<add key="chatMessageDirectory" value=""/>
         <add key="streamUrl" value="https://twitch.tv/Your_Channel"/>
         <add key="headless" value="false"/>

--- a/StreamViewerBot/MainScreen.Designer.cs
+++ b/StreamViewerBot/MainScreen.Designer.cs
@@ -76,6 +76,9 @@
             this.label4 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
+            this.browseUserAgentList = new System.Windows.Forms.Button();
+            this.txtUserAgentList = new System.Windows.Forms.TextBox();
+            this.lblUserAgentList = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.startStopButton)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.picVulture)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numRefreshMinutes)).BeginInit();
@@ -102,7 +105,7 @@
             // 
             // txtStreamUrl
             // 
-            this.txtStreamUrl.Location = new System.Drawing.Point(83, 267);
+            this.txtStreamUrl.Location = new System.Drawing.Point(83, 292);
             this.txtStreamUrl.Name = "txtStreamUrl";
             this.txtStreamUrl.Size = new System.Drawing.Size(306, 23);
             this.txtStreamUrl.TabIndex = 1;
@@ -110,7 +113,7 @@
             // lblStreamUrl
             // 
             this.lblStreamUrl.AutoSize = true;
-            this.lblStreamUrl.Location = new System.Drawing.Point(12, 270);
+            this.lblStreamUrl.Location = new System.Drawing.Point(12, 295);
             this.lblStreamUrl.Name = "lblStreamUrl";
             this.lblStreamUrl.Size = new System.Drawing.Size(65, 15);
             this.lblStreamUrl.TabIndex = 2;
@@ -550,11 +553,40 @@
             this.label6.TabIndex = 48;
             this.label6.Text = ">";
             // 
+            // browseUserAgentList
+            // 
+            this.browseUserAgentList.Location = new System.Drawing.Point(109, 265);
+            this.browseUserAgentList.Name = "browseUserAgentList";
+            this.browseUserAgentList.Size = new System.Drawing.Size(34, 23);
+            this.browseUserAgentList.TabIndex = 50;
+            this.browseUserAgentList.Text = "...";
+            this.browseUserAgentList.UseVisualStyleBackColor = true;
+            this.browseUserAgentList.Click += new System.EventHandler(this.browseUserAgentList_Click);
+            // 
+            // txtUserAgentList
+            // 
+            this.txtUserAgentList.Location = new System.Drawing.Point(151, 265);
+            this.txtUserAgentList.Name = "txtUserAgentList";
+            this.txtUserAgentList.Size = new System.Drawing.Size(238, 23);
+            this.txtUserAgentList.TabIndex = 49;
+            // 
+            // lblUserAgentList
+            // 
+            this.lblUserAgentList.AutoSize = true;
+            this.lblUserAgentList.Location = new System.Drawing.Point(12, 269);
+            this.lblUserAgentList.Name = "lblUserAgentList";
+            this.lblUserAgentList.Size = new System.Drawing.Size(91, 15);
+            this.lblUserAgentList.TabIndex = 51;
+            this.lblUserAgentList.Text = "User-Agent List:";
+            // 
             // MainScreen
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(813, 396);
+            this.Controls.Add(this.lblUserAgentList);
+            this.Controls.Add(this.browseUserAgentList);
+            this.Controls.Add(this.txtUserAgentList);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
@@ -672,6 +704,9 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Button browseUserAgentList;
+        private System.Windows.Forms.TextBox txtUserAgentList;
+        private System.Windows.Forms.Label lblUserAgentList;
     }
 }
 


### PR DESCRIPTION
As requested and agreed on #156, I have finished the implementation of specifying User-Agent strings for bots.

I have implemented it like a mixture of proxy list and chat message list. I added a browse button and textbox below the proxy list. When the user selects a file, it parses it line-by-line and creates a user agent list. Afterwards, it is fed to BotCore via `ExecuteNeedsDto`. Finally, it is fed to browser options when launching Chrome instances.

The list is ordered on par with proxy list. I mean, if proxy list contains 10 proxies and user agent list contains 10 proxies, they are pairing with respect to their lines: First proxy uses first user agent string, second proxy users second user agent string, etc. However, if user agent list is shorter than proxy list, then they are used from the start again. By using this method, the system continues to work even with 1 user agent string.

I tested it by starting bots and navigating to [useragentstring.com](http://useragentstring.com/) to check if I can really see what I entered in user agent list file. I saw different user agent string working correctly.

If any modification is required for this PR, please tell, so I can quickly update as necessary.